### PR TITLE
[Feat] send verification code & verify, singUp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
+++ b/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
@@ -69,7 +69,6 @@ public class SecurityConfig {
         //csrf disable
         http
                 .csrf((auth) -> auth.disable());
-
         //From 로그인 방식 disable
         http
                 .formLogin((auth) -> auth.disable());
@@ -81,7 +80,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join").permitAll()
+                        .requestMatchers("/login", "/", "/join", "/user/**").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN") // /admin경로는 ADMIN이라는 역할을 가진 고객만 가능
                         .requestMatchers("/reissue").permitAll()
                         .anyRequest().authenticated()); // 나머지는 그냥 다 로그인 해야 접근 가능하게

--- a/src/main/java/com/example/ddingsroom/controller/AdminController.java
+++ b/src/main/java/com/example/ddingsroom/controller/AdminController.java
@@ -1,15 +1,12 @@
 package com.example.ddingsroom.controller;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-
 @ResponseBody
 @Controller
 public class AdminController {
     @GetMapping("/admin")
     public String adminP() {
-
         return "admin Controller";
     }
 }

--- a/src/main/java/com/example/ddingsroom/controller/JoinController.java
+++ b/src/main/java/com/example/ddingsroom/controller/JoinController.java
@@ -1,26 +1,38 @@
 package com.example.ddingsroom.controller;
 
+import com.example.ddingsroom.dto.CodeSendDTO;
+import com.example.ddingsroom.dto.CodeVerifyDTO;
 import com.example.ddingsroom.dto.JoinDTO;
+import com.example.ddingsroom.dto.SignUpDTO;
 import com.example.ddingsroom.service.JoinService;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
-@ResponseBody
+import java.util.Map;
+
+@RestController
+@RequestMapping(value="/user", produces="application/json; charset=utf8")
 public class JoinController {
-
     private final JoinService joinService;
-
     public JoinController(JoinService joinService) {
-
         this.joinService = joinService;
     }
-
     @PostMapping("/join")
     public String joinProcess(JoinDTO joinDTO) {
         System.out.println(joinDTO.getUsername());
         joinService.joinProcess(joinDTO);
         return "ok";
+    }
+    @PostMapping("/code-send")
+    public ResponseEntity<String> codeSend(@RequestBody CodeSendDTO codeSendDTO) {
+        return joinService.autentication1(codeSendDTO);
+    }
+    @PostMapping("/code-verify")
+    public ResponseEntity<String> codeVerify(@RequestBody CodeVerifyDTO codeVerifyDTO) {
+        return joinService.verifyCode(codeVerifyDTO);
+    }
+    @PostMapping("/sign-up")
+    public ResponseEntity<String> signUp(@RequestBody SignUpDTO signUpDTO) {
+        return joinService.signUp(signUpDTO);
     }
 }

--- a/src/main/java/com/example/ddingsroom/dto/CodeSendDTO.java
+++ b/src/main/java/com/example/ddingsroom/dto/CodeSendDTO.java
@@ -1,0 +1,12 @@
+package com.example.ddingsroom.dto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodeSendDTO {
+    private String email;
+}

--- a/src/main/java/com/example/ddingsroom/dto/CodeVerifyDTO.java
+++ b/src/main/java/com/example/ddingsroom/dto/CodeVerifyDTO.java
@@ -1,0 +1,13 @@
+package com.example.ddingsroom.dto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodeVerifyDTO {
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/example/ddingsroom/dto/SignUpDTO.java
+++ b/src/main/java/com/example/ddingsroom/dto/SignUpDTO.java
@@ -1,15 +1,14 @@
 package com.example.ddingsroom.dto;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Setter
 @Getter
-public class JoinDTO {
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignUpDTO {
     private String email;
     private String username;
     private String password;

--- a/src/main/java/com/example/ddingsroom/entity/UserEntity.java
+++ b/src/main/java/com/example/ddingsroom/entity/UserEntity.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Data
 @Setter
@@ -16,9 +18,12 @@ public class UserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
-
+    private String email;
     private String username;
     private String password;
-
+    private String age;
+    private String studentNumber;
     private String role;
+    private String state;
+    private LocalDateTime registrationDate;
 }

--- a/src/main/java/com/example/ddingsroom/entity/VerificationCode.java
+++ b/src/main/java/com/example/ddingsroom/entity/VerificationCode.java
@@ -1,0 +1,27 @@
+package com.example.ddingsroom.entity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class VerificationCode {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true, length = 6)
+    private String code;
+    @Column(nullable = false)
+    private String email;
+    @Column(nullable = false)
+    private LocalDateTime publishedDate;
+    public VerificationCode(String code, String email) {
+        this.code = code;
+        this.email = email;
+        this.publishedDate = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/ddingsroom/jwt/JWTFilter.java
+++ b/src/main/java/com/example/ddingsroom/jwt/JWTFilter.java
@@ -16,30 +16,31 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 public class JWTFilter extends OncePerRequestFilter {
-
     private final JWTUtil jwtUtil;
-
     public JWTFilter(JWTUtil jwtUtil) {
-
         this.jwtUtil = jwtUtil;
     }
-
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        System.out.println("JWTFilter: 필터 실행됨 (요청 URI: " + request.getRequestURI() + ")");
         // 헤더에서 access키에 담긴 토큰을 꺼냄
-        String accessToken = request.getHeader("access");
-
+        String accessToken = request.getHeader("Authorization"); // 이거 원래 access였음 -> 영상 확인필요
+        System.out.println("Access Token: " + accessToken);
         // 토큰이 없다면 다음 필터로 넘김
         if (accessToken == null) {
+            System.out.println("JWTFilter: No access token found, skipping authentication");
             filterChain.doFilter(request, response);
             return;
         }
+        // 이것도 확인 필요.
+        accessToken = accessToken.substring(7);
+        accessToken = accessToken.trim();
 
         // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
+            System.out.println("JWTFilter: Token expired");
             //response body
             PrintWriter writer = response.getWriter();
             writer.print("access token expired");
@@ -47,23 +48,22 @@ public class JWTFilter extends OncePerRequestFilter {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
-
         // 토큰이 access인지 확인 (발급시 페이로드에 명시)
         String category = jwtUtil.getCategory(accessToken);
-
         if (!category.equals("access")) {
+            System.out.println("JWTFilter: Invalid access token");
             //response body
             PrintWriter writer = response.getWriter();
             writer.print("invalid access token");
-
             //response status code
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
-
         // username, role 값을 획득
         String username = jwtUtil.getUsername(accessToken);
         String role = jwtUtil.getRole(accessToken);
+
+        System.out.println("JWTFilter: Setting authentication for " + username + " with role " + role);
 
         UserEntity userEntity = new UserEntity();
         userEntity.setUsername(username);

--- a/src/main/java/com/example/ddingsroom/repository/UserRepository.java
+++ b/src/main/java/com/example/ddingsroom/repository/UserRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<UserEntity, Integer> {
     Boolean existsByUsername(String username);
     UserEntity findByUsername(String username);
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/ddingsroom/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/example/ddingsroom/repository/VerificationCodeRepository.java
@@ -1,0 +1,11 @@
+package com.example.ddingsroom.repository;
+
+import com.example.ddingsroom.entity.VerificationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
+    Optional<VerificationCode> findByCode(String code); // 코드로 조회
+    Optional<VerificationCode> findByEmail(String email); // 유저이름으로 조회
+}
+

--- a/src/main/java/com/example/ddingsroom/service/JoinService.java
+++ b/src/main/java/com/example/ddingsroom/service/JoinService.java
@@ -1,21 +1,37 @@
 package com.example.ddingsroom.service;
-
+import com.example.ddingsroom.dto.CodeSendDTO;
+import com.example.ddingsroom.dto.CodeVerifyDTO;
 import com.example.ddingsroom.dto.JoinDTO;
+import com.example.ddingsroom.dto.SignUpDTO;
 import com.example.ddingsroom.entity.UserEntity;
+import com.example.ddingsroom.entity.VerificationCode;
 import com.example.ddingsroom.repository.UserRepository;
+import com.example.ddingsroom.repository.VerificationCodeRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 public class JoinService {
-
+    private final VerificationCodeRepository verificationCodeRepository;
+    private final JavaMailSender javaMailSender;
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-
-    public JoinService(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
-
+    private final SecureRandom secureRandom = new SecureRandom();
+    public String generateRandomCode() {
+        return String.format("%06d", secureRandom.nextInt(1000000));
+    }
+    public JoinService(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder, JavaMailSender javaMailSender, VerificationCodeRepository verificationCodeRepository) {
         this.userRepository = userRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.javaMailSender = javaMailSender;
+        this.verificationCodeRepository = verificationCodeRepository;
     }
 
     public void joinProcess(JoinDTO joinDTO) {
@@ -35,5 +51,59 @@ public class JoinService {
         data.setPassword(bCryptPasswordEncoder.encode(password));
         data.setRole("ROLE_ADMIN");
         userRepository.save(data);
+    }
+
+    public ResponseEntity<String> autentication1(CodeSendDTO codeSendDTO) {
+        Optional<VerificationCode> existingCode = verificationCodeRepository.findByEmail(codeSendDTO.getEmail());
+        existingCode.ifPresent(verificationCodeRepository::delete);
+
+        String randomCode = generateRandomCode();
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(codeSendDTO.getEmail());
+        mailMessage.setSubject("subject");
+        mailMessage.setText(String.valueOf(randomCode));
+        javaMailSender.send(mailMessage);
+
+        VerificationCode verificationCode = new VerificationCode(randomCode, codeSendDTO.getEmail());
+        verificationCodeRepository.save(verificationCode);
+
+        return ResponseEntity.ok("Received email: " + codeSendDTO.getEmail());
+    }
+
+    @Transactional
+    public ResponseEntity<String> verifyCode(CodeVerifyDTO codeVerifyDTO) {
+        String email = codeVerifyDTO.getEmail();
+        String code = codeVerifyDTO.getCode();
+
+        Optional<VerificationCode> verificationCodeOptional = verificationCodeRepository.findByEmail(email);
+
+        if (verificationCodeOptional.isPresent()) {
+            VerificationCode verificationCode = verificationCodeOptional.get();
+
+            if (verificationCode.getCode().equals(code)) {
+                verificationCodeRepository.delete(verificationCode);
+                return ResponseEntity.ok("인증이 완료되었습니다.");
+            } else {
+                return ResponseEntity.badRequest().body("인증에 실패했습니다.");
+            }
+        } else {
+            return ResponseEntity.badRequest().body("인증에 실패했습니다.");
+        }
+    }
+
+    public ResponseEntity<String> signUp(SignUpDTO signUpDTO) {
+        boolean emailExists = userRepository.existsByUsername(signUpDTO.getEmail());
+        if (emailExists) return ResponseEntity.badRequest().body("이미 가입된 계정입니다.");
+        UserEntity newUser = new UserEntity();
+        newUser.setEmail(signUpDTO.getEmail());
+        newUser.setUsername(signUpDTO.getUsername());
+        newUser.setPassword(bCryptPasswordEncoder.encode(signUpDTO.getPassword()));
+        newUser.setAge(signUpDTO.getAge());
+        newUser.setStudentNumber(signUpDTO.getStudentNumber());
+        newUser.setRole("ROLE_USER");
+        newUser.setState("nomal");
+        newUser.setRegistrationDate(LocalDateTime.now());
+        userRepository.save(newUser);
+        return ResponseEntity.ok("회원가입이 완료되었습니다.");
     }
 }


### PR DESCRIPTION
# 📢 이메일 인증 기반 회원가입 기능 추가 & jwt인증 필터 오류 수정

## ✨ 주요 변경 사항
1. **이메일 인증 코드 발송 기능 추가**
   - 사용자가 이메일 입력 시, 6자리 인증 코드를 생성하여 메일 발송
   - 기존 인증 코드가 있을 경우 삭제 후 새로운 코드 저장

2. **인증 코드 검증 기능 추가**
   - 사용자가 입력한 인증 코드가 유효한지 검증(db에 코드와 사용자 이메일 매핑 저장)
   - 인증 성공 시, 해당 인증 코드 삭제

3. **회원가입 기능 추가**
   - 이메일 인증을 완료한 사용자만 회원가입 가능
   - 비밀번호는 `BCrypt`로 해싱하여 저장
   - 기본 권한(`ROLE_USER`) 및 가입 상태(`nomal`) 설정 -> 가입 상태는 추후 회의를 통해 결정해야할 듯

## 🔧 구현 상세
- `JoinController` 추가 (`/user` 엔드포인트 관리)
- `JoinService` 로직 추가 (이메일 인증 및 회원가입 처리)
- `VerificationCodeRepository` 활용하여 인증 코드 저장 및 검증
- `Spring Mail`을 이용한 이메일 발송 (`SimpleMailMessage` 사용)

## 🛠 추가된 라이브러리
- **Spring Mail (`spring-boot-starter-mail`)**

## 🚀 테스트 방법
1. **이메일로 인증 코드 요청** → `POST /user/code-send`
2. **인증 코드 확인 요청** → `POST /user/code-verify`
3. **회원가입 요청** → `POST /user/sign-up`
