### PR TITLE
[Feat] 예약취소, 예약, 회원탈퇴 유효성 검증, 회원탈퇴 방식 변경

### DIFF
--- a/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
+++ b/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                                 Arrays.asList(
                                         "http://localhost:3000",
                                         "https://dding-sroom-frontend.vercel.app",
-                                        "https://ddingsroom.com"
+                                        "https://ddingsroom.com",
+                                        "https://www.ddingsroom.com"
                                 )
                         );
                         configuration.setAllowedMethods(Collections.singletonList("*"));

--- a/src/main/java/com/example/ddingsroom/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/ddingsroom/reservation/repository/ReservationRepository.java
@@ -47,6 +47,14 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
 
     List<ReservationEntity> findByUserOrderByCreatedAtDesc(UserEntity user, Pageable pageable);
 
+    // 특정 날짜의 사용자 예약 시간 합계 조회 (하루 2시간 제한용)
+    @Query("SELECT r FROM ReservationEntity r WHERE r.user = :user AND r.status = 'RESERVED' " +
+           "AND r.startTime >= :startOfDay AND r.startTime < :endOfDay")
+    List<ReservationEntity> findReservationsByUserAndDate(
+            @Param("user") UserEntity user, 
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay);
+
     @Transactional
     void deleteByUser(UserEntity user);
 }

--- a/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
+++ b/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
@@ -2,7 +2,10 @@ package com.example.ddingsroom.user.controller;
 
 import com.example.ddingsroom.user.dto.*;
 import com.example.ddingsroom.user.service.JoinService;
+import com.example.ddingsroom.user.dto.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -57,5 +60,25 @@ public class JoinController {
     @PutMapping("/change-username")
     public ResponseEntity<ResponseDTO> changeUsername(@RequestBody com.example.ddingsroom.user.dto.ChangeUsernameDTO changeUsernameDTO) {
         return joinService.changeUsername(changeUsernameDTO);
+    }
+
+    @PostMapping("/verify-email")
+    public ResponseEntity<ResponseDTO> verifyEmail(@RequestBody EmailVerificationDTO emailVerificationDTO) {
+        // 인증된 사용자 정보 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String tokenEmail = userDetails.getUserEntity().getEmail();
+        
+        return joinService.verifyUserEmail(tokenEmail, emailVerificationDTO.getEmail());
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ResponseDTO> withdrawUser() {
+        // 인증된 사용자 정보 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        int userId = userDetails.getUserEntity().getId();
+        
+        return joinService.withdrawUserById(userId);
     }
 }

--- a/src/main/java/com/example/ddingsroom/user/dto/EmailVerificationDTO.java
+++ b/src/main/java/com/example/ddingsroom/user/dto/EmailVerificationDTO.java
@@ -1,0 +1,16 @@
+package com.example.ddingsroom.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailVerificationDTO {
+    private String email;
+
+    public EmailVerificationDTO() {}
+
+    public EmailVerificationDTO(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/example/ddingsroom/user/service/JoinService.java
+++ b/src/main/java/com/example/ddingsroom/user/service/JoinService.java
@@ -336,4 +336,49 @@ public class JoinService {
                     .body(new ResponseDTO("사용자명 변경 중 오류가 발생했습니다: " + e.getMessage()));
         }
     }
+
+    @Transactional
+    public ResponseEntity<ResponseDTO> withdrawUserById(int userId) {
+        try {
+            Optional<UserEntity> userOptional = userRepository.findById(userId);
+            if (userOptional.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ResponseDTO("해당 사용자를 찾을 수 없습니다."));
+            }
+
+            UserEntity user = userOptional.get();
+
+            // 기존 로직 그대로 유지 - 관련 데이터 삭제
+            reservationRepository.deleteByUser(user);
+            refreshRepository.deleteByUsername(user.getEmail());
+            verificationCodeRepository.findByEmail(user.getEmail()).ifPresent(verificationCodeRepository::delete);
+
+            userRepository.delete(user);
+
+            return ResponseEntity.ok(new ResponseDTO("회원탈퇴가 성공적으로 완료되었습니다."));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseDTO("회원탈퇴 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
+
+    public ResponseEntity<ResponseDTO> verifyUserEmail(String tokenEmail, String inputEmail) {
+        try {
+            // 입력값 검증
+            if (inputEmail == null || inputEmail.trim().isEmpty()) {
+                return ResponseEntity.badRequest().body(new ResponseDTO("이메일을 입력해주세요."));
+            }
+            
+            // 사용자가 입력한 이메일과 토큰의 이메일 비교
+            if (tokenEmail.equals(inputEmail.trim())) {
+                return ResponseEntity.ok(new ResponseDTO("사용자 이메일이 일치합니다."));
+            } else {
+                return ResponseEntity.badRequest().body(new ResponseDTO("사용자 이메일이 일치하지 않습니다."));
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseDTO("이메일 검증 중 오류가 발생했습니다."));
+        }
+    }
 }


### PR DESCRIPTION
## [Feat] 예약취소, 예약, 회원탈퇴 유효성 검증, 회원탈퇴 방식 변경

 1. 예약취소 API 시간 제한 추가
  - 구현: 현재 시간이 예약 시작시간과 종료시간 사이(이용중)이거나 종료시간 이후인 경우 취소 방지
  - 메시지:
    - 이용중: "이용 중인 예약은 취소할 수 없습니다."
    - 종료후: "이용이 완료된 예약은 취소할 수 없습니다."

 2. 하루 2시간 예약 제한 로직 추가
  - 구현: 예약 생성 로직의 마지막에 추가
  - 기능:
    - 예약일 기준 00시~24시 사이 총 예약시간 계산
    - 2시간 초과시 제한
    - 남은 시간에 따른 적절한 메시지 반환

 3. 이메일 일치 확인 API 생성
  - 엔드포인트: POST /user/verify-email
  - 구현: 토큰에서 추출한 이메일과 사용자 입력 이메일 비교
  - 응답:
    - 일치: "사용자 이메일이 일치합니다." (200)
    - 불일치: "사용자 이메일이 일치하지 않습니다." (400)

 4. 회원탈퇴 API 토큰 기반으로 변경
  - 엔드포인트: DELETE /user/withdraw
  - 구현:
    - 기존 이메일 입력 방식에서 토큰에서 userId 추출 방식으로 변경
    - 기존 탈퇴 로직은 그대로 유지

 [새로 생성된 파일]
  - EmailVerificationDTO.java: 이메일 검증 API용 DTO
