### PR TITLE
[Feat] 커뮤니티 게시글 CRUD & 댓글 CRUD 개발 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs += '-parameters'
+}
+
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/example/ddingsroom/community_post/controller/CommunityPostController.java
+++ b/src/main/java/com/example/ddingsroom/community_post/controller/CommunityPostController.java
@@ -1,0 +1,70 @@
+package com.example.ddingsroom.community_post.controller;
+
+import com.example.ddingsroom.community_post.dto.BaseResponseDTO;
+import com.example.ddingsroom.community_post.dto.CommunityPostRequestDTO;
+import com.example.ddingsroom.community_post.dto.CommunityPostResponseDTO;
+import com.example.ddingsroom.community_post.service.CommunityPostService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/community-posts")
+public class CommunityPostController {
+
+    private final CommunityPostService service;
+
+    @Autowired
+    public CommunityPostController(CommunityPostService service) {
+        this.service = service;
+    }
+
+    // 게시글 생성
+    @PostMapping
+    public ResponseEntity<BaseResponseDTO> createCommunityPost(@RequestBody CommunityPostRequestDTO dto) {
+        BaseResponseDTO response = service.createCommunityPost(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 게시글 수정
+    @PutMapping
+    public ResponseEntity<BaseResponseDTO> updateCommunityPost(@RequestBody CommunityPostRequestDTO dto) {
+        BaseResponseDTO response = service.updateCommunityPost(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 게시글 삭제
+    @DeleteMapping
+    public ResponseEntity<BaseResponseDTO> deleteCommunityPost(@RequestBody CommunityPostRequestDTO dto) {
+        BaseResponseDTO response = service.deleteCommunityPost(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    // 조건부 조회 (기존 방식 유지)
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> retrieveCommunityPost(
+            @RequestParam(required = false) Long post_id,
+            @RequestParam(required = false) Long user_id,
+            @RequestParam(required = false) Integer category
+    ) {
+        List<CommunityPostResponseDTO> posts = service.retrieveCommunityPost(post_id, user_id, category);
+        return ResponseEntity.ok(Map.of("posts", posts));
+    }
+
+    // 전체 목록 조회
+    @GetMapping
+    public ResponseEntity<BaseResponseDTO> getAllCommunityPosts() {
+        BaseResponseDTO response = service.getAllCommunityPosts();
+        return ResponseEntity.ok(response);
+    }
+
+    // 특정 게시글 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponseDTO> getCommunityPost(@PathVariable Long id) {
+        BaseResponseDTO response = service.getCommunityPost(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/controller1/CommunityPostCommentController.java
+++ b/src/main/java/com/example/ddingsroom/community_post/controller1/CommunityPostCommentController.java
@@ -1,0 +1,50 @@
+package com.example.ddingsroom.community_post.controller1;
+
+import com.example.ddingsroom.community_post.dto1.BaseResponseDTO;
+import com.example.ddingsroom.community_post.dto1.CommunityPostCommentRequestDTO;
+import com.example.ddingsroom.community_post.service1.CommunityPostCommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community-posts/comments")
+public class CommunityPostCommentController {
+
+    private final CommunityPostCommentService service;
+
+    @Autowired
+    public CommunityPostCommentController(CommunityPostCommentService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponseDTO> createComment(@RequestBody CommunityPostCommentRequestDTO dto) {
+        BaseResponseDTO response = service.createComment(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<BaseResponseDTO> updateComment(@RequestBody CommunityPostCommentRequestDTO dto) {
+        BaseResponseDTO response = service.updateComment(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<BaseResponseDTO> deleteComment(@RequestBody CommunityPostCommentRequestDTO dto) {
+        BaseResponseDTO response = service.deleteComment(dto);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<BaseResponseDTO> getCommentsByPostId(@PathVariable Long postId) {
+        BaseResponseDTO response = service.getCommentsByPostId(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{commentId}")
+    public ResponseEntity<BaseResponseDTO> getComment(@PathVariable Long commentId) {
+        BaseResponseDTO response = service.getComment(commentId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto/BaseResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto/BaseResponseDTO.java
@@ -1,0 +1,38 @@
+package com.example.ddingsroom.community_post.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BaseResponseDTO {
+    private String message;
+    private String error;
+    private Object data;  // 데이터 필드 추가!
+
+    // 성공 응답 (메시지만)
+    public static BaseResponseDTO success(String message) {
+        return BaseResponseDTO.builder()
+                .message(message)
+                .build();
+    }
+
+    // 성공 응답 (데이터 포함)
+    public static BaseResponseDTO success(String message, Object data) {
+        return BaseResponseDTO.builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 오류 응답
+    public static BaseResponseDTO error(String error) {
+        return BaseResponseDTO.builder()
+                .error(error)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto/CommunityPostRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto/CommunityPostRequestDTO.java
@@ -1,0 +1,27 @@
+package com.example.ddingsroom.community_post.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityPostRequestDTO {
+
+    @JsonProperty("post_id")
+    private Long postId;        // update, delete용
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("content")
+    private String content;
+
+    @JsonProperty("category")
+    private Integer category;   // API 문서에서 "..."로 되어있지만 테이블에서 int이므로 Integer 사용
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto/CommunityPostResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto/CommunityPostResponseDTO.java
@@ -1,0 +1,38 @@
+package com.example.ddingsroom.community_post.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityPostResponseDTO {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("content")
+    private String content;
+
+    @JsonProperty("category")
+    private Integer category;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("message")
+    private String message;
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto1/BaseResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto1/BaseResponseDTO.java
@@ -1,0 +1,35 @@
+package com.example.ddingsroom.community_post.dto1;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BaseResponseDTO {
+    private String message;
+    private String error;
+    private Object data;
+
+    public static BaseResponseDTO success(String message) {
+        return BaseResponseDTO.builder()
+                .message(message)
+                .build();
+    }
+
+    public static BaseResponseDTO success(String message, Object data) {
+        return BaseResponseDTO.builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static BaseResponseDTO error(String error) {
+        return BaseResponseDTO.builder()
+                .error(error)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto1/CommunityPostCommentRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto1/CommunityPostCommentRequestDTO.java
@@ -1,0 +1,24 @@
+package com.example.ddingsroom.community_post.dto1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityPostCommentRequestDTO {
+
+    @JsonProperty("comment_id")
+    private Long commentId;
+
+    @JsonProperty("post_id")
+    private Long postId;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("comment_content")
+    private String commentContent;
+}

--- a/src/main/java/com/example/ddingsroom/community_post/dto1/CommunityPostCommentResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post/dto1/CommunityPostCommentResponseDTO.java
@@ -1,0 +1,35 @@
+package com.example.ddingsroom.community_post.dto1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityPostCommentResponseDTO {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("post_id")
+    private Long postId;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("comment_content")
+    private String commentContent;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("message")
+    private String message;
+}

--- a/src/main/java/com/example/ddingsroom/community_post/entity/CommunityPostEntity.java
+++ b/src/main/java/com/example/ddingsroom/community_post/entity/CommunityPostEntity.java
@@ -1,0 +1,51 @@
+package com.example.ddingsroom.community_post.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "CommunityPost")
+public class CommunityPostEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "post-title")
+    private String title;
+
+    @Column(name = "post_content")
+    private String content;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "cetegory") // 테이블의 오타에 맞춤
+    private Integer category;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/entity1/CommunityPostCommentEntity.java
+++ b/src/main/java/com/example/ddingsroom/community_post/entity1/CommunityPostCommentEntity.java
@@ -1,0 +1,48 @@
+package com.example.ddingsroom.community_post.entity1;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "CommunityPostComment")
+public class CommunityPostCommentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "comment_content")
+    private String commentContent;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/repository/CommunityPostRepository.java
+++ b/src/main/java/com/example/ddingsroom/community_post/repository/CommunityPostRepository.java
@@ -1,0 +1,17 @@
+package com.example.ddingsroom.community_post.repository;
+
+import com.example.ddingsroom.community_post.entity.CommunityPostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommunityPostRepository extends JpaRepository<CommunityPostEntity, Long> {
+
+    List<CommunityPostEntity> findByUserId(Long userId);
+
+    List<CommunityPostEntity> findByCategory(Integer category);
+
+    List<CommunityPostEntity> findByUserIdAndCategory(Long userId, Integer category);
+}

--- a/src/main/java/com/example/ddingsroom/community_post/repository1/CommunityPostCommentRepository.java
+++ b/src/main/java/com/example/ddingsroom/community_post/repository1/CommunityPostCommentRepository.java
@@ -1,0 +1,15 @@
+package com.example.ddingsroom.community_post.repository1;
+
+import com.example.ddingsroom.community_post.entity1.CommunityPostCommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostCommentEntity, Long> {
+
+    List<CommunityPostCommentEntity> findByPostId(Long postId);
+    List<CommunityPostCommentEntity> findByUserId(Long userId);
+    Long countByPostId(Long postId);
+}

--- a/src/main/java/com/example/ddingsroom/community_post/service/CommunityPostService.java
+++ b/src/main/java/com/example/ddingsroom/community_post/service/CommunityPostService.java
@@ -1,0 +1,161 @@
+package com.example.ddingsroom.community_post.service;
+
+import com.example.ddingsroom.community_post.dto.BaseResponseDTO;
+import com.example.ddingsroom.community_post.dto.CommunityPostRequestDTO;
+import com.example.ddingsroom.community_post.dto.CommunityPostResponseDTO;
+import com.example.ddingsroom.community_post.entity.CommunityPostEntity;
+import com.example.ddingsroom.community_post.repository.CommunityPostRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CommunityPostService {
+
+    private final CommunityPostRepository repository;
+
+    @Autowired
+    public CommunityPostService(CommunityPostRepository repository) {
+        this.repository = repository;
+    }
+
+    // 게시글 생성
+    public BaseResponseDTO createCommunityPost(CommunityPostRequestDTO dto) {
+        try {
+            CommunityPostEntity entity = new CommunityPostEntity();
+            entity.setUserId(dto.getUserId());
+            entity.setTitle(dto.getTitle());
+            entity.setContent(dto.getContent());
+            entity.setCategory(dto.getCategory());
+
+            CommunityPostEntity savedEntity = repository.save(entity);
+            CommunityPostResponseDTO responseDTO = convertToResponseDTO(savedEntity);
+
+            return BaseResponseDTO.success("게시글이 성공적으로 생성되었습니다!", responseDTO);
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("게시글 생성 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 게시글 수정
+    public BaseResponseDTO updateCommunityPost(CommunityPostRequestDTO dto) {
+        try {
+            Optional<CommunityPostEntity> optional = repository.findById(dto.getPostId());
+            if (optional.isEmpty()) {
+                return BaseResponseDTO.error("게시글을 찾을 수 없습니다.");
+            }
+
+            CommunityPostEntity entity = optional.get();
+            if (!entity.getUserId().equals(dto.getUserId())) {
+                return BaseResponseDTO.error("작성자만 수정할 수 있습니다.");
+            }
+
+            entity.setTitle(dto.getTitle());
+            entity.setContent(dto.getContent());
+            entity.setCategory(dto.getCategory());
+
+            CommunityPostEntity updatedEntity = repository.save(entity);
+            CommunityPostResponseDTO responseDTO = convertToResponseDTO(updatedEntity);
+
+            return BaseResponseDTO.success("게시글이 성공적으로 수정되었습니다!", responseDTO);
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("게시글 수정 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 게시글 삭제
+    public BaseResponseDTO deleteCommunityPost(CommunityPostRequestDTO dto) {
+        try {
+            Optional<CommunityPostEntity> optional = repository.findById(dto.getPostId());
+            if (optional.isEmpty()) {
+                return BaseResponseDTO.error("삭제하려는 게시글이 존재하지 않습니다.");
+            }
+
+            CommunityPostEntity entity = optional.get();
+            if (!entity.getUserId().equals(dto.getUserId())) {
+                return BaseResponseDTO.error("작성자만 삭제할 수 있습니다.");
+            }
+
+            repository.deleteById(dto.getPostId());
+            return BaseResponseDTO.success("게시글이 성공적으로 삭제되었습니다!");
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("게시글 삭제 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 조건부 조회 (기존 retrieve 메서드)
+    public List<CommunityPostResponseDTO> retrieveCommunityPost(Long postId, Long userId, Integer category) {
+        try {
+            List<CommunityPostEntity> posts;
+
+            if (postId != null) {
+                posts = repository.findById(postId)
+                        .map(List::of)
+                        .orElse(Collections.emptyList());
+            } else if (userId != null && category != null) {
+                posts = repository.findByUserIdAndCategory(userId, category);
+            } else if (userId != null) {
+                posts = repository.findByUserId(userId);
+            } else if (category != null) {
+                posts = repository.findByCategory(category);
+            } else {
+                posts = repository.findAll();
+            }
+
+            return posts.stream().map(this::convertToResponseDTO).collect(Collectors.toList());
+
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    // 전체 목록 조회 - 수정됨!
+    public BaseResponseDTO getAllCommunityPosts() {
+        try {
+            List<CommunityPostEntity> posts = repository.findAll();
+            List<CommunityPostResponseDTO> responseDTOs = posts.stream()
+                    .map(this::convertToResponseDTO)
+                    .collect(Collectors.toList());
+
+            return BaseResponseDTO.success("게시글 목록 조회 성공", responseDTOs);
+        } catch (Exception e) {
+            return BaseResponseDTO.error("게시글 목록 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 특정 게시글 조회 - 수정됨!
+    public BaseResponseDTO getCommunityPost(Long id) {
+        try {
+            Optional<CommunityPostEntity> optional = repository.findById(id);
+            if (optional.isPresent()) {
+                CommunityPostResponseDTO responseDTO = convertToResponseDTO(optional.get());
+                return BaseResponseDTO.success("게시글 조회 성공", responseDTO);
+            } else {
+                return BaseResponseDTO.error("해당 게시글을 찾을 수 없습니다. ID: " + id);
+            }
+        } catch (Exception e) {
+            return BaseResponseDTO.error("게시글 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // Entity를 ResponseDTO로 변환
+    private CommunityPostResponseDTO convertToResponseDTO(CommunityPostEntity entity) {
+        CommunityPostResponseDTO dto = new CommunityPostResponseDTO();
+        dto.setId(entity.getId());
+        dto.setUserId(entity.getUserId());
+        dto.setTitle(entity.getTitle());
+        dto.setContent(entity.getContent());
+        dto.setCategory(entity.getCategory());
+        dto.setCreatedAt(entity.getCreatedAt());
+        dto.setUpdatedAt(entity.getUpdatedAt());
+        dto.setMessage("성공");
+        return dto;
+    }
+}

--- a/src/main/java/com/example/ddingsroom/community_post/service1/CommunityPostCommentService.java
+++ b/src/main/java/com/example/ddingsroom/community_post/service1/CommunityPostCommentService.java
@@ -1,0 +1,123 @@
+package com.example.ddingsroom.community_post.service1;
+
+import com.example.ddingsroom.community_post.dto1.BaseResponseDTO;
+import com.example.ddingsroom.community_post.dto1.CommunityPostCommentRequestDTO;
+import com.example.ddingsroom.community_post.dto1.CommunityPostCommentResponseDTO;
+import com.example.ddingsroom.community_post.entity1.CommunityPostCommentEntity;
+import com.example.ddingsroom.community_post.repository1.CommunityPostCommentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CommunityPostCommentService {
+
+    private final CommunityPostCommentRepository repository;
+
+    @Autowired
+    public CommunityPostCommentService(CommunityPostCommentRepository repository) {
+        this.repository = repository;
+    }
+
+    public BaseResponseDTO createComment(CommunityPostCommentRequestDTO dto) {
+        try {
+            CommunityPostCommentEntity entity = new CommunityPostCommentEntity();
+            entity.setPostId(dto.getPostId());
+            entity.setUserId(dto.getUserId());
+            entity.setCommentContent(dto.getCommentContent());
+
+            CommunityPostCommentEntity savedEntity = repository.save(entity);
+            CommunityPostCommentResponseDTO responseDTO = convertToResponseDTO(savedEntity);
+
+            return BaseResponseDTO.success("댓글이 성공적으로 생성되었습니다!", responseDTO);
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("댓글 생성 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    public BaseResponseDTO updateComment(CommunityPostCommentRequestDTO dto) {
+        try {
+            Optional<CommunityPostCommentEntity> optional = repository.findById(dto.getCommentId());
+            if (optional.isEmpty()) {
+                return BaseResponseDTO.error("댓글을 찾을 수 없습니다.");
+            }
+
+            CommunityPostCommentEntity entity = optional.get();
+            if (!entity.getUserId().equals(dto.getUserId())) {
+                return BaseResponseDTO.error("작성자만 수정할 수 있습니다.");
+            }
+
+            entity.setCommentContent(dto.getCommentContent());
+            CommunityPostCommentEntity updatedEntity = repository.save(entity);
+            CommunityPostCommentResponseDTO responseDTO = convertToResponseDTO(updatedEntity);
+
+            return BaseResponseDTO.success("댓글이 성공적으로 수정되었습니다!", responseDTO);
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("댓글 수정 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    public BaseResponseDTO deleteComment(CommunityPostCommentRequestDTO dto) {
+        try {
+            Optional<CommunityPostCommentEntity> optional = repository.findById(dto.getCommentId());
+            if (optional.isEmpty()) {
+                return BaseResponseDTO.error("삭제하려는 댓글이 존재하지 않습니다.");
+            }
+
+            CommunityPostCommentEntity entity = optional.get();
+            if (!entity.getUserId().equals(dto.getUserId())) {
+                return BaseResponseDTO.error("작성자만 삭제할 수 있습니다.");
+            }
+
+            repository.deleteById(dto.getCommentId());
+            return BaseResponseDTO.success("댓글이 성공적으로 삭제되었습니다!");
+
+        } catch (Exception e) {
+            return BaseResponseDTO.error("댓글 삭제 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    public BaseResponseDTO getCommentsByPostId(Long postId) {
+        try {
+            List<CommunityPostCommentEntity> comments = repository.findByPostId(postId);
+            List<CommunityPostCommentResponseDTO> responseDTOs = comments.stream()
+                    .map(this::convertToResponseDTO)
+                    .collect(Collectors.toList());
+
+            return BaseResponseDTO.success("댓글 목록 조회 성공", responseDTOs);
+        } catch (Exception e) {
+            return BaseResponseDTO.error("댓글 목록 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    public BaseResponseDTO getComment(Long commentId) {
+        try {
+            Optional<CommunityPostCommentEntity> optional = repository.findById(commentId);
+            if (optional.isPresent()) {
+                CommunityPostCommentResponseDTO responseDTO = convertToResponseDTO(optional.get());
+                return BaseResponseDTO.success("댓글 조회 성공", responseDTO);
+            } else {
+                return BaseResponseDTO.error("해당 댓글을 찾을 수 없습니다. ID: " + commentId);
+            }
+        } catch (Exception e) {
+            return BaseResponseDTO.error("댓글 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    private CommunityPostCommentResponseDTO convertToResponseDTO(CommunityPostCommentEntity entity) {
+        CommunityPostCommentResponseDTO dto = new CommunityPostCommentResponseDTO();
+        dto.setId(entity.getId());
+        dto.setPostId(entity.getPostId());
+        dto.setUserId(entity.getUserId());
+        dto.setCommentContent(entity.getCommentContent());
+        dto.setCreatedAt(entity.getCreatedAt());
+        dto.setUpdatedAt(entity.getUpdatedAt());
+        dto.setMessage("성공");
+        return dto;
+    }
+}

--- a/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
+++ b/src/main/java/com/example/ddingsroom/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join", "/user/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/login", "/", "/join", "/api/**", "/user/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN") // /admin경로는 ADMIN이라는 역할을 가진 고객만 가능
                         .requestMatchers("/reissue", "/api/reservations/**").permitAll()
                         .anyRequest().authenticated()); // 나머지는 그냥 다 로그인 해야 접근 가능하게

--- a/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 @Service


### PR DESCRIPTION
[Feat] 커뮤니티 게시글 CRUD & 댓글 CRUD 개발 완료
***

# Pull Request - Community Post & Comment 기능 추가

## 개요
- 커뮤니티 게시글(CommunityPost) 및 댓글(CommunityPostComment)에 대한 CRUD 기능 구현
- 공통 응답 DTO(`BaseResponseDTO`) 적용으로 일관된 API 응답 구조 확립
- Controller / Service / Repository / Entity / DTO 계층 분리

***

## 추가/변경된 클래스

### Community Post (게시글)
- **Controller**
  - `CommunityPostController` : 게시글 생성, 수정, 삭제, 조회, 검색 API 추가  
- **Service**
  - `CommunityPostService` : 게시글 CRUD/검색 로직 구현  
- **Repository**
  - `CommunityPostRepository` : `findByUserId`, `findByCategory`, `findByUserIdAndCategory` 메서드 정의  
- **Entity**
  - `CommunityPostEntity` : 게시글 테이블 매핑 (`id`, `userId`, `title`, `content`, `category`, `createdAt`, `updatedAt`)  
- **DTO**
  - `CommunityPostRequestDTO` : 게시글 요청 데이터용 DTO  
  - `CommunityPostResponseDTO` : 게시글 응답 데이터용 DTO  
  - `BaseResponseDTO` : 공통 응답 구조  

***

### Community Post Comment (댓글)
- **Controller**
  - `CommunityPostCommentController` : 댓글 생성, 수정, 삭제, 조회 API 추가  
- **Service**
  - `CommunityPostCommentService` : 댓글 CRUD 로직 구현  
- **Repository**
  - `CommunityPostCommentRepository` : `findByPostId`, `findByUserId`, `countByPostId` 메서드 정의  
- **Entity**
  - `CommunityPostCommentEntity` : 댓글 테이블 매핑 (`id`, `postId`, `userId`, `commentContent`, `createdAt`, `updatedAt`)  
- **DTO**
  - `CommunityPostCommentRequestDTO` : 댓글 요청 데이터용 DTO  
  - `CommunityPostCommentResponseDTO` : 댓글 응답 데이터용 DTO  
  - `BaseResponseDTO` : 공통 응답 구조  

***

## 주요 내용
- 게시글 및 댓글 CRUD API 제공
- 작성자 검증(본인만 수정 및 삭제 가능) 추가
- 예외 발생 시 `BaseResponseDTO.error` 로 메시지 반환
- 전체 조회, 조건 검색, 단건 조회 기능 구현  


=> 모든 기능 구현 완료하였습니다. 확인 부탁드립니다.