### PR TITLE
[Refactoring] Long 타입 비교 연산자 오류로 인한 예약 취소 권한 검증 실패 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'com.h2database:h2'  // H2 데이터베이스 추가
+    runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
@@ -210,8 +210,8 @@ public class ReservationService {
         try {
             ReservationEntity reservation = reservationRepository.findById(requestDTO.getReservationId())
                     .orElseThrow(() -> new EntityNotFoundException("예약을 찾을 수 없습니다."));
-            
-            if (reservation.getUser().getId() != requestDTO.getUserId()) {
+
+            if (!reservation.getUser().getId().equals(requestDTO.getUserId())) {
                 return new BaseResponseDTO("본인의 예약만 취소할 수 있습니다.");
             }
             

--- a/src/main/java/com/example/ddingsroom/suggest_post/util/SuggestPostLocation.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post/util/SuggestPostLocation.java
@@ -11,8 +11,7 @@ public enum SuggestPostLocation {
     STUDY_ROOM_2(2, "스터디룸2"),
     STUDY_ROOM_3(3, "스터디룸3"),
     STUDY_ROOM_4(4, "스터디룸4"),
-    STUDY_ROOM_5(5, "스터디룸5"),
-    ETC(6, "기타");
+    STUDY_ROOM_5(5, "스터디룸5");
 
     private final int value;
     private final String name;


### PR DESCRIPTION
## [Refactoring] Long 타입 비교 연산자 오류로 인한 예약 취소 권한 검증 실패 수정

## 문제 상황
배포 환경에서 사용자가 본인의 예약을 취소하려고 할 때, 정상적인 요청임에도 불구하고 "본인의 예약만 취소할 수 있습니다."라는 오류가 발생하여 예약 취소가 불가능한 문제가 발생함.

### 문제
- **로컬 환경**: 예약 취소 정상 작동
- **배포 환경**: 400 Bad Request - "본인의 예약만 취소할 수 있습니다." 오류 발생
- 그런데 프론트엔드에서 전송하는 `userId`와 `reservationId`는 모두 정상적인 숫자(number) 타입으로 확인했음

## 원인 분석

### 문제 코드
```java
if (reservation.getUser().getId() != requestDTO.getUserId()) {
    return new BaseResponseDTO("본인의 예약만 취소할 수 있습니다.");
}
```

### 근본 원인: 알고보니 Java Long 타입의 객체 비교 특성에 있엇음

Java에서 Long 타입은 참조 타입임. != 또는 == 연산자를 사용하면 값이 아닌 객체의 참조를 비교함.

#### Java의 Long 캐싱 메커니즘
- Java는 -128 ~ 127 범위의 Long 값에 대해 자동으로 캐싱함.
- 이 범위 내의 값은 동일한 객체 인스턴스를 재사용하게됨
- 128 이상의 값은 매번 새로운 객체를 생성함.


### 이상했던점 --> 왜 로컬에서는 작동했는가?

- 로컬 환경: 테스트용 userId가 작은 값 (예: 1, 2, 3 등) → 캐싱 범위 내 → != 비교 정상 작동했던것
- 배포 환경: 실제 userId가 큰 값 (예: 285) → 캐싱 범위 밖 → != 비교 실패하게됨

## 해결 방법

### 수정된 코드
```java
if (!reservation.getUser().getId().equals(requestDTO.getUserId())) {
    return new BaseResponseDTO("본인의 예약만 취소할 수 있습니다.");
}
```

### 변경 사항
- != 연산자 → .equals() 메서드로 변경
- 참조 비교에서 값 비교로 변경하여 객체의 실제 값을 비교하도록 수정


